### PR TITLE
Update strings.tmLanguage.json

### DIFF
--- a/syntaxes/strings.tmLanguage.json
+++ b/syntaxes/strings.tmLanguage.json
@@ -16,16 +16,22 @@
 		"keywords": {
 			"name": "keyword.control",
 			"begin": "^\"",
-			"end": "\""
+			"end": "(?<!\\\\)\"(?=\\s*=)",
+			"patterns": [
+				{
+					"name": "storage",
+					"match": "%[.0-9]*[$]?([fiduxogc@]|ld|lu|lx)"
+				}
+			]
 		},
 		"strings": {
 			"name": "string.quoted.double",
 			"begin": "\"",
-			"end": "\"",
+			"end": "(?<!\\\\)\"",
 			"patterns": [
 				{
 					"name": "storage",
-					"match": "%[.0-9]*([fduxogc@]|ld|lu|lx)"
+					"match": "%[.0-9]*[$]?([fiduxogc@]|ld|lu|lx)"
 				}
 			]
 		},


### PR DESCRIPTION
## Update (for Xcode 12.4)
Fixes #2 

- add variable detection also for source text (you can maybe do it as another pattern?)
- #2: don't detect `\"` as end of strings
- detect `=` after source text / keyword
- include `%0$@` for positional specifiers, see also: [String Format Specifiers](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/Strings/Articles/formatSpecifiers.html#//apple_ref/doc/uid/TP40004265-SW4)


Note: Double escaped `\\\\` is needed, 1st for JSON decoding and 2nd for regex interpretation. 